### PR TITLE
refactor(consumer): split main.go into smaller separate files

### DIFF
--- a/consumer/error.go
+++ b/consumer/error.go
@@ -1,0 +1,9 @@
+package main
+
+import "log"
+
+func failOnError(err error, msg string) {
+	if err != nil {
+		log.Panicf("%s: %s", msg, err)
+	}
+}

--- a/consumer/handler.go
+++ b/consumer/handler.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+
+	db "github.com/christoff-linde/pih-core-go/consumer/database"
+)
+
+func (appConfig *appConfig) handleCreateSensor() (db.Sensor, error) {
+	sensor, err := appConfig.DB.CreateSensor(context.Background(), db.CreateSensorParams{
+		SensorName: "esp32-test-02",
+	})
+
+	return sensor, err
+}
+
+func (appConfig *appConfig) handleGetSensorBySensorId(id int32) db.Sensor {
+	sensor, err := appConfig.DB.GetSensorById(context.Background(), id)
+	failOnError(err, "Could not fetch sensor")
+
+	return sensor
+}
+
+func (appConfig *appConfig) handleGetSensorByName(name string) (db.Sensor, error) {
+	sensor, err := appConfig.DB.GetSensorByName(context.Background(), name)
+
+	return sensor, err
+}
+
+func (appConfig *appConfig) handleCreateSensorMetadata(sensor db.Sensor) db.SensorMetadatum {
+	metadata, err := appConfig.DB.CreateSensorMetadata(context.Background(), db.CreateSensorMetadataParams{
+		ID:       1,
+		SensorID: sensor.ID,
+	})
+	failOnError(err, "Failed to create sensorMetadata")
+
+	return metadata
+}

--- a/consumer/internal/model.go
+++ b/consumer/internal/model.go
@@ -1,0 +1,7 @@
+package internal
+
+type DeviceData struct {
+	DeviceID    string  `json:"device_id"`
+	Temperature float64 `json:"temperature"`
+	Humidity    float64 `json:"humidity"`
+}


### PR DESCRIPTION
this moves out error handler, handlers to interact with db, and any
other relevant logic into separate files.
