### PR TITLE
chr 86 setup dependabot action for outdated dependencies

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,9 +1,6 @@
 name: "Changelog"
 
 on:
-  push:
-    branches: ["main"]
-    tags: ["*"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,17 +1,20 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-
 version: 2
 updates:
-  # Enable version updates for golang dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-  # Enable version updates for GitHub Actions
-  - package-ecosystem: "github-actions"
-    # Workflow files stored in the default location of `.github/workflows`
-    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
-    directory: "/"
-    schedule:
-      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      # Prefix all commit messages with "npm: "
+      prefix: "chore"
+    reviewers:
+      - "octocat"
+      - "christoff-linde"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase-if-necessary"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+
+version: 2
+updates:
+  # Enable version updates for golang dependencies
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request includes updates to the GitHub workflows, specifically the removal of certain triggers from the changelog workflow and the addition of a Dependabot configuration.

Changes to GitHub workflows:

* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85L4-L6): Removed the `push` trigger for branches and tags, leaving only the `workflow_dispatch` trigger.
* [`.github/workflows/dependabot.yml`](diffhunk://#diff-844c68181213ce31638b949e99f9f4df97859cb53840020a31c603a236346ba6R1-R20): Added a new Dependabot configuration to automate dependency updates for GitHub Actions and Go modules, including scheduling, labeling, commit message prefixing, reviewers, and versioning strategy.

### Changelog

- **feat(workflows): add dependabot for gh actions & golang packages**
- **fix(workflows): update dependabot workflow file structure to conform to requirements**
- **chore(workflows): remove automatic run of changelog action**
